### PR TITLE
Bugfix:SQL syntax error at getPrimaryKeysFromTable

### DIFF
--- a/src/Console/GenerateModelsCommand.php
+++ b/src/Console/GenerateModelsCommand.php
@@ -305,7 +305,7 @@ class GenerateModelsCommand extends GeneratorCommand {
     }
 
     function getPrimaryKeysFromTable($table) {
-        $sql = "SHOW KEYS FROM $table WHERE Key_name = 'PRIMARY'";
+        $sql = "SHOW KEYS FROM `$table` WHERE Key_name = 'PRIMARY'";
         $primaryKeys = DB::select(DB::raw($sql));
 
         $prep = [];


### PR DESCRIPTION
In case the column name is a reserved database name we need to use backticks.
