### PR TITLE
Fix problem with the formatting of the name of the relationship call functions

### DIFF
--- a/src/Console/GenerateModelsCommand.php
+++ b/src/Console/GenerateModelsCommand.php
@@ -21,6 +21,7 @@ class GenerateModelsCommand extends GeneratorCommand
     protected $name = 'models:generate';
 
     private static $namespace;
+
     /**
      * The console command description.
      *
@@ -228,8 +229,6 @@ class GenerateModelsCommand extends GeneratorCommand
             $ns = env('APP_NAME','App\Models');
         }
 
-        //convert forward slashes in the namespace to backslashes
-        $ns = str_replace('/', '\\', $ns);
         return $ns;
 
     }
@@ -256,7 +255,7 @@ class GenerateModelsCommand extends GeneratorCommand
 
             $function = "
     public function $hasManyFunctionName() {".'
-        return $this->hasMany'."(\\".self::$namespace."\\$hasManyModel::class, '$key1', '$key2');
+        return $this->hasMany'."('".self::$namespace."\\$hasManyModel', '$key1', '$key2');
     }
 ";
             $functions .= $function;
@@ -277,7 +276,7 @@ class GenerateModelsCommand extends GeneratorCommand
 
             $function = "
     public function $hasOneFunctionName() {".'
-        return $this->hasOne'."(\\".self::$namespace."\\$hasOneModel::class, '$key1', '$key2');
+        return $this->hasOne'."('".self::$namespace."\\$hasOneModel', '$key1', '$key2');
     }
 ";
             $functions .= $function;
@@ -298,7 +297,7 @@ class GenerateModelsCommand extends GeneratorCommand
 
             $function = "
     public function $belongsToFunctionName() {".'
-        return $this->belongsTo'."(\\".self::$namespace."\\$belongsToModel::class, '$key1', '$key2');
+        return $this->belongsTo'."('".self::$namespace."\\$belongsToModel', '$key1', '$key2');
     }
 ";
             $functions .= $function;
@@ -320,7 +319,7 @@ class GenerateModelsCommand extends GeneratorCommand
 
             $function = "
     public function $belongsToManyFunctionName() {".'
-        return $this->belongsToMany'."(\\".self::$namespace."\\$belongsToManyModel::class, '$through', '$key1', '$key2');
+        return $this->belongsToMany'."('".self::$namespace."\\$belongsToManyModel', '$through', '$key1', '$key2');
     }
 ";
             $functions .= $function;
@@ -332,13 +331,13 @@ class GenerateModelsCommand extends GeneratorCommand
     private function getPluralFunctionName($modelName)
     {
         $modelName = lcfirst($modelName);
-        return str_plural($modelName);
+        return str_plural(mb_strtolower($modelName));
     }
 
     private function getSingularFunctionName($modelName)
     {
         $modelName = lcfirst($modelName);
-        return str_singular($modelName);
+        return str_singular(mb_strtolower($modelName));
     }
 
     private function generateModelNameFromTableName($table)

--- a/src/Console/GenerateModelsCommand.php
+++ b/src/Console/GenerateModelsCommand.php
@@ -155,6 +155,7 @@ class GenerateModelsCommand extends GeneratorCommand
 
     private function generateEloquentModel($destinationFolder, $table, $rules) {
 
+
         //1. Determine path where the file should be generated
         $modelName = $this->generateModelNameFromTableName($table);
         $filePathToGenerate = $destinationFolder . '/'.$modelName.'.php';
@@ -185,13 +186,22 @@ class GenerateModelsCommand extends GeneratorCommand
             $hasOneFunctions,
         ]);
 
+        $keys = $this->schemaGenerator->getPrimaryKeys($table);
+
+        if(sizeof($keys) == 1){
+            $primaryKeys = "'".current($keys)."'";
+        }else{
+            $primaryKeys = "array('".implode(",",$keys)."')";
+        }
+
         //3. prepare template data
         $templateData = array(
             'NAMESPACE' => self::$namespace,
             'NAME' => $modelName,
             'TABLENAME' => $table,
             'FILLABLE' => $fillable,
-            'FUNCTIONS' => $functions
+            'FUNCTIONS' => $functions,
+            'PRIMARYKEY' => $primaryKeys
         );
 
         $templatePath = $this->getTemplatePath();

--- a/src/Console/GenerateModelsCommand.php
+++ b/src/Console/GenerateModelsCommand.php
@@ -258,8 +258,8 @@ class GenerateModelsCommand extends GeneratorCommand
         $functions = '';
         foreach ($rulesContainer as $rules) {
             $hasManyModel = $this->generateModelNameFromTableName($rules[0]);
-            $key1 = $rules[1];
-            $key2 = $rules[2];
+            $key1 = mb_strtolower($rules[1]);
+            $key2 = mb_strtolower($rules[2]);
 
             $hasManyFunctionName = $this->getPluralFunctionName($hasManyModel);
 
@@ -279,8 +279,8 @@ class GenerateModelsCommand extends GeneratorCommand
         $functions = '';
         foreach ($rulesContainer as $rules) {
             $hasOneModel = $this->generateModelNameFromTableName($rules[0]);
-            $key1 = $rules[1];
-            $key2 = $rules[2];
+            $key1 = mb_strtolower($rules[1]);
+            $key2 = mb_strtolower($rules[2]);
 
             $hasOneFunctionName = $this->getSingularFunctionName($hasOneModel);
 
@@ -300,8 +300,8 @@ class GenerateModelsCommand extends GeneratorCommand
         $functions = '';
         foreach ($rulesContainer as $rules) {
             $belongsToModel = $this->generateModelNameFromTableName($rules[0]);
-            $key1 = $rules[1];
-            $key2 = $rules[2];
+            $key1 = mb_strtolower($rules[1]);
+            $key2 = mb_strtolower($rules[2]);
 
             $belongsToFunctionName = $this->getSingularFunctionName($belongsToModel);
 
@@ -321,9 +321,9 @@ class GenerateModelsCommand extends GeneratorCommand
         $functions = '';
         foreach ($rulesContainer as $rules) {
             $belongsToManyModel = $this->generateModelNameFromTableName($rules[0]);
-            $through = $rules[1];
-            $key1 = $rules[2];
-            $key2 = $rules[3];
+            $through = mb_strtolower($rules[1]);
+            $key1 = mb_strtolower($rules[2]);
+            $key2 = mb_strtolower($rules[3]);
 
             $belongsToManyFunctionName = $this->getPluralFunctionName($belongsToManyModel);
 
@@ -610,4 +610,3 @@ class GenerateModelsCommand extends GeneratorCommand
 
         return $tp;
     }
-}

--- a/src/Console/templates/model.txt
+++ b/src/Console/templates/model.txt
@@ -11,6 +11,8 @@ class $NAME$ extends Model {
     protected $table = '$TABLENAME$';
     protected $fillable = [$FILLABLE$];
 
+    protected $primaryKey = $PRIMARYKEY$;
+
 $FUNCTIONS$
 
 }


### PR DESCRIPTION
If the tables in the database will be in upcase routine converted the name of the relationship role in not nice standard
